### PR TITLE
Feat/embedding improvements

### DIFF
--- a/notorch/cli/train.py
+++ b/notorch/cli/train.py
@@ -1,15 +1,12 @@
 import logging
-from typing import Callable
 
 import hydra
-import lightning as L
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
 from rich import print
 
 import notorch.cli.utils.instantiate as instantiate
 from notorch.cli.utils.resolvers import register_resolvers
 from notorch.cli.utils.utils import build_group_transform_configs
-from notorch.data.datamodule import NotorchDataModule
 from notorch.data.dataset import NotorchDataset
 from notorch.lightning_models.model import NotorchModel
 

--- a/notorch/cli/utils/instantiate.py
+++ b/notorch/cli/utils/instantiate.py
@@ -1,4 +1,5 @@
 """largely copied from https://github.com/ashleve/lightning-hydra-template/tree/main"""
+
 import hydra
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.loggers import Logger

--- a/notorch/nn/gnn/embed.py
+++ b/notorch/nn/gnn/embed.py
@@ -1,14 +1,9 @@
-from __future__ import annotations
-
 from copy import copy
-from typing import Literal
 
 import torch.nn as nn
 
 from notorch.conf import DEFAULT_HIDDEN_DIM
 from notorch.data.models.graph import Graph
-
-Reduction = Literal["mean", "sum", "min", "max"]
 
 
 class GraphEmbedding(nn.Module):

--- a/notorch/nn/gnn/embed.py
+++ b/notorch/nn/gnn/embed.py
@@ -38,5 +38,5 @@ class GraphEmbedding(nn.Module):
         return self.edge.num_embeddings
 
     @classmethod
-    def from_transform(cls, transform: GraphTransform, **kwargs) -> GraphEmbedding:    
+    def from_transform(cls, transform: GraphTransform, **kwargs) -> GraphEmbedding:
         return cls(transform.num_node_types, transform.num_edge_types, **kwargs)

--- a/notorch/nn/gnn/embed.py
+++ b/notorch/nn/gnn/embed.py
@@ -1,14 +1,21 @@
+from __future__ import annotations
+
 from copy import copy
 
 import torch.nn as nn
 
 from notorch.conf import DEFAULT_HIDDEN_DIM
 from notorch.data.models.graph import Graph
+from notorch.transforms.base import GraphTransform
+from notorch.transforms.conf import DEFAULT_NUM_ATOM_TYPES, DEFAULT_NUM_BOND_TYPES
 
 
 class GraphEmbedding(nn.Module):
     def __init__(
-        self, num_node_types: int, num_edge_types: int, hidden_dim: int = DEFAULT_HIDDEN_DIM
+        self,
+        num_node_types: int = DEFAULT_NUM_ATOM_TYPES,
+        num_edge_types: int = DEFAULT_NUM_BOND_TYPES,
+        hidden_dim: int = DEFAULT_HIDDEN_DIM,
     ):
         super().__init__()
 
@@ -29,3 +36,7 @@ class GraphEmbedding(nn.Module):
     @property
     def num_edge_types(self) -> int:
         return self.edge.num_embeddings
+
+    @classmethod
+    def from_transform(cls, transform: GraphTransform, **kwargs) -> GraphEmbedding:    
+        return cls(transform.num_node_types, transform.num_edge_types, **kwargs)

--- a/notorch/nn/loss.py
+++ b/notorch/nn/loss.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 
 from jaxtyping import Bool, Float
-from numpy.typing import ArrayLike
 import torch
 from torch import Tensor
 import torch.nn as nn
@@ -9,7 +8,6 @@ import torch.nn.functional as F
 
 
 class _LossFunctionBase(nn.Module):
-
     @abstractmethod
     def forward(
         self,

--- a/notorch/nn/metrics.py
+++ b/notorch/nn/metrics.py
@@ -1,7 +1,6 @@
 from typing import Literal
 
 from jaxtyping import Bool, Float
-from numpy.typing import ArrayLike
 import torch
 from torch import Tensor
 import torch.nn as nn
@@ -103,11 +102,7 @@ class AUPRC(_ClassificationMetricBase):
 
 
 class Accuracy(_LossFunctionBase):
-    def __init__(
-        self,
-        task: Literal["binary", "multilabel"],
-        threshold: float = 0.5,
-    ):
+    def __init__(self, task: Literal["binary", "multilabel"], threshold: float = 0.5):
         super().__init__()
 
         self.task = task

--- a/notorch/transforms/base.py
+++ b/notorch/transforms/base.py
@@ -4,6 +4,7 @@ import textwrap
 from typing import ClassVar, Protocol
 
 from notorch.conf import REPR_INDENT
+from notorch.data.models.graph import BatchedGraph, Graph
 
 
 class Transform[S, T, T_batched](Protocol):
@@ -17,6 +18,11 @@ class Transform[S, T, T_batched](Protocol):
 
     def __call__(self, input: S) -> T: ...
     def collate(self, inputs: Collection[T]) -> T_batched: ...
+
+
+class GraphTransform[S](Transform[S, Graph, BatchedGraph]):
+    num_node_types: int
+    num_edge_types: int
 
 
 @dataclass
@@ -34,6 +40,10 @@ class Pipeline[S, T, T_batched](Transform[S, T, T_batched]):
         return output  # type: ignore
 
     def __repr__(self) -> str:
-        text = "\n".join(f"({i}): {transform}" for i, transform in enumerate(self.transforms))
+        text = "\n".join(
+            f"({i}): {transform}" for i, transform in enumerate(self.transforms)
+        )
 
-        return "\n".join([f"{type(self).__name__}(", textwrap.indent(text, REPR_INDENT), ")"])
+        return "\n".join(
+            [f"{type(self).__name__}(", textwrap.indent(text, REPR_INDENT), ")"]
+        )

--- a/notorch/transforms/base.py
+++ b/notorch/transforms/base.py
@@ -40,10 +40,6 @@ class Pipeline[S, T, T_batched](Transform[S, T, T_batched]):
         return output  # type: ignore
 
     def __repr__(self) -> str:
-        text = "\n".join(
-            f"({i}): {transform}" for i, transform in enumerate(self.transforms)
-        )
+        text = "\n".join(f"({i}): {transform}" for i, transform in enumerate(self.transforms))
 
-        return "\n".join(
-            [f"{type(self).__name__}(", textwrap.indent(text, REPR_INDENT), ")"]
-        )
+        return "\n".join([f"{type(self).__name__}(", textwrap.indent(text, REPR_INDENT), ")"])

--- a/notorch/transforms/bond.py
+++ b/notorch/transforms/bond.py
@@ -86,6 +86,3 @@ class MultiTypeBondTransform:
         text = "\n".join(lines)
 
         return "\n".join([f"{type(self).__name__}(", textwrap.indent(text, REPR_INDENT), ")"])
-
-    def stringify_choices(self):
-        return list(map(str))


### PR DESCRIPTION
something approaching a more intuitive way to specify the number of types as input to an embedding layer. The general challenge is that the specification of the number of types is defined in the `data.transforms` section of a config, but this information needs to make its way to the `model.modules` section. Moreover, if a user manually adjusts the embedding subtypes (e.g., reduces the number of atom types from the default) then they need to figure out the total number of types to specify. It's not _terrible_, and they could always just specify a number that's too big. But it would be nice if there was a way to just take of this for the user. I don't think this current solution is it though...