### PR TITLE
Clean up GNN code

### DIFF
--- a/notorch/data/models/graph.py
+++ b/notorch/data/models/graph.py
@@ -1,4 +1,3 @@
-from copy import copy
 from dataclasses import InitVar, dataclass, field
 import textwrap
 from typing import Iterable, Self
@@ -244,5 +243,5 @@ class BatchedGraph(Graph):
             f"node_feats: Tensor(shape={self.node_feats.shape})",
             f"edge_feats: Tensor(shape={self.edge_feats.shape})",
             f"device={self.__device}",
-            f"batch_size={len(self)}" "",
+            f"batch_size={len(self)}",
         ]

--- a/notorch/data/models/graph.py
+++ b/notorch/data/models/graph.py
@@ -1,3 +1,4 @@
+from copy import copy
 from dataclasses import InitVar, dataclass, field
 import textwrap
 from typing import Iterable, Self
@@ -8,10 +9,11 @@ from torch import Tensor
 from torch.types import Device
 
 from notorch.conf import REPR_INDENT
+from notorch.utils.utils import UpdateMixin
 
 
 @dataclass(repr=False, eq=False)
-class Graph:
+class Graph(UpdateMixin):
     """A :class:`Graph` represents the feature representation of graph."""
 
     node_feats: Int[Tensor, "V t_v"]

--- a/notorch/data/models/point_cloud.py
+++ b/notorch/data/models/point_cloud.py
@@ -10,10 +10,11 @@ from torch import Tensor
 from torch.types import Device
 
 from notorch.conf import REPR_INDENT
+from notorch.utils.utils import UpdateMixin
 
 
 @dataclass(repr=False, eq=False)
-class PointCloud:
+class PointCloud(UpdateMixin):
     node_feats: Num[Tensor, "V t"]
     """a tensor of shape ``V x t`` containing the node types/features."""
     coords: Float[Tensor, "V r"]

--- a/notorch/nn/gnn/agg.py
+++ b/notorch/nn/gnn/agg.py
@@ -24,27 +24,27 @@ class Sum(Aggregation):
     def forward(
         self, G: Annotated[BatchedGraph, "(V d_v) (E d_e) b"], **kwargs
     ) -> Float[Tensor, "b d_v"]:
-        H = scatter_sum(G.node_feats, G.batch_node_index, dim=0, dim_size=len(G))
+        hiddens = scatter_sum(G.node_feats, G.batch_node_index, dim=0, dim_size=len(G))
 
-        return H
+        return hiddens
 
 
 class Mean(Aggregation):
     def forward(
         self, G: Annotated[BatchedGraph, "(V d_v) (E d_e) b"], **kwargs
     ) -> Float[Tensor, "b d_v"]:
-        H = scatter_mean(G.node_feats, G.batch_node_index, dim=0, dim_size=len(G))
+        hiddens = scatter_mean(G.node_feats, G.batch_node_index, dim=0, dim_size=len(G))
 
-        return H
+        return hiddens
 
 
 class Max(Aggregation):
     def forward(
         self, G: Annotated[BatchedGraph, "(V d_v) (E d_e) b"], **kwargs
     ) -> Float[Tensor, "b d_v"]:
-        H, _ = scatter_max(G.node_feats, G.batch_node_index, dim=0, dim_size=len(G))
+        hiddens, _ = scatter_max(G.node_feats, G.batch_node_index, dim=0, dim_size=len(G))
 
-        return H
+        return hiddens
 
 
 class Gated(Aggregation):
@@ -58,9 +58,9 @@ class Gated(Aggregation):
     ) -> Float[Tensor, "b d_v"]:
         scores = self.a(G.node_feats)
         alpha = scatter_softmax(scores, G.batch_node_index, dim=0, dim_size=len(G)).unsqueeze(1)
-        H = scatter_sum(alpha * G.node_feats, G.batch_node_index, dim=0, dim_size=len(G))
+        hiddens = scatter_sum(alpha * G.node_feats, G.batch_node_index, dim=0, dim_size=len(G))
 
-        return H
+        return hiddens
 
 
 class SDPAttention(Aggregation):
@@ -81,6 +81,6 @@ class SDPAttention(Aggregation):
             / self.sqrt_key_dim
         )
         alpha = scatter_softmax(scores, G.batch_node_index, dim=0, dim_size=len(G)).unsqueeze(1)
-        H = scatter_sum(alpha * G.node_feats, G.batch_node_index, dim=0, dim_size=len(G))
+        hiddens = scatter_sum(alpha * G.node_feats, G.batch_node_index, dim=0, dim_size=len(G))
 
-        return H
+        return hiddens

--- a/notorch/nn/gnn/chemprop.py
+++ b/notorch/nn/gnn/chemprop.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from copy import copy
 
+from jaxtyping import Float, Int
+from torch import Tensor
 import torch.nn as nn
 from torch_scatter import scatter
 
@@ -22,33 +24,25 @@ class ChempropLayer(nn.Module):
         super().__init__()
 
         self.act = act()
-        self.message = nn.Identity()
         self.reduce = reduce
         self.update = nn.Sequential(nn.Linear(hidden_dim, hidden_dim, bias), nn.Dropout(dropout))
 
-    # def _forward(self, G: Graph) -> Graph:
-    #     G_h = copy(G)
-    #     src, dest = G.edge_index.unbind(0)
-
-    #     H_uv = self.act(G.E)
-    #     M_uv = H_uv
-    #     M_v = scatter(M_uv, dest, dim=0, dim_size=G.num_nodes, reduce=self.reduce)
-    #     M_uv = M_v[src] - M_uv[G.rev_index]
-    #     H_uv = self.update(M_uv)
-    #     G_h.E = H_uv
-
-    #     return G_h # Graph(G.V, H_uv, G.edge_index, G.rev_index)
-
-    def forward(self, E, V, edge_index, rev_index) -> Graph:
+    def forward(
+        self,
+        edge_feats: Float[Tensor, "E d_h"],
+        node_feats: Float[Tensor, "V *"],
+        edge_index: Int[Tensor, "2 E"],
+        rev_index: Int[Tensor, "E"],
+    ) -> Float[Tensor, "E d_h"]:
         src, dest = edge_index.unbind(0)
 
-        H_uv = self.act(E)
-        M_uv = H_uv
-        M_v = scatter(M_uv, dest, dim=0, dim_size=len(V), reduce=self.reduce)
-        M_uv = M_v[src] - M_uv[rev_index]
-        H_uv = self.update(M_uv)
+        edge_hiddens = self.act(edge_feats)
+        messages = edge_hiddens
+        node_messages = scatter(messages, dest, dim=0, dim_size=len(node_feats), reduce=self.reduce)
+        edge_messages = node_messages[src] - messages[rev_index]
+        edge_hiddens = self.update(edge_messages)
 
-        return H_uv
+        return edge_hiddens
 
     def extra_repr(self):
         return f"(reduce): {self.reduce}"
@@ -77,16 +71,7 @@ class ChempropBlock(nn.Module):
 
         if residual:
             layers = [Residual(layer) for layer in layers]
-            # residual connection on edge features
-            # def add_edge_attrs(G1, G2):
-            #     G = copy(G1)
-            #     G.E = G1.E + G2.E
 
-            #     return G
-
-            # layers = [Residual(layer, add_edge_attrs) for layer in layers]
-
-        # self.block = nn.Sequential(*layers)
         self.layers = nn.ModuleList(layers)
         self.hidden_dim = hidden_dim
         self.reduce = reduce
@@ -95,21 +80,14 @@ class ChempropBlock(nn.Module):
     def depth(self) -> int:
         return len(self.layers)
 
-    # def _forward(self, G: Graph) -> Graph:
-    #     G_t = copy(G)
-    #     G_t.E = G.V[G.edge_index[0]] + G.E
-    #     G_t = self.block(G_t)
-    #     G_t.V = scatter(G_t.E, G_t.edge_index[0], dim=0, dim_size=G.num_nodes, reduce=self.reduce)
-
-    #     return G_t
-
     def forward(self, G: Graph) -> Graph:
-        E = G.V[G.edge_index[0]] + G.E
+        src, dest = G.edge_index.unbind(0)
+        E = G.node_feats[src] + G.edge_feats
         for layer in self.layers:
-            E = layer(E, G.V, G.edge_index, G.rev_index)
+            E = layer(E, G.node_feats, G.edge_index, G.rev_index)
 
         G_t = copy(G)
-        G_t.V = scatter(E, G.edge_index[0], dim=0, dim_size=G.num_nodes, reduce=self.reduce)
-        G_t.E = E
+        G_t.node_feats = scatter(E, dest, dim=0, dim_size=G.num_nodes, reduce=self.reduce)
+        G_t.edge_feats = E
 
         return G_t

--- a/notorch/nn/gnn/embed.py
+++ b/notorch/nn/gnn/embed.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from copy import copy
-
 import torch.nn as nn
 
 from notorch.conf import DEFAULT_HIDDEN_DIM
@@ -23,11 +21,7 @@ class GraphEmbedding(nn.Module):
         self.edge = nn.EmbeddingBag(num_edge_types, hidden_dim, mode="sum")
 
     def forward(self, G: Graph) -> Graph:
-        G_emb = copy(G)
-        G_emb.node_feats = self.node(G_emb.node_feats)
-        G_emb.edge_feats = self.edge(G_emb.edge_feats)
-
-        return G_emb
+        return G.update(node_feats=self.node(G.node_feats), edge_feats=self.edge(G.edge_feats))
 
     @property
     def num_node_types(self) -> int:

--- a/notorch/nn/gnn/embed.py
+++ b/notorch/nn/gnn/embed.py
@@ -24,8 +24,8 @@ class GraphEmbedding(nn.Module):
 
     def forward(self, G: Graph) -> Graph:
         G_emb = copy(G)
-        G_emb.V = self.node(G_emb.V)
-        G_emb.E = self.edge(G_emb.E)
+        G_emb.node_feats = self.node(G_emb.node_feats)
+        G_emb.edge_feats = self.edge(G_emb.edge_feats)
 
         return G_emb
 

--- a/notorch/nn/rbf.py
+++ b/notorch/nn/rbf.py
@@ -14,14 +14,14 @@ class RBFEmbedding(nn.Module):
         width = (d_min - d_max) / num_bases
 
         self.register_buffer("means", means.unsqueeze(0))
-        self.width = 0.5 * 1 / width**2
+        self.width = 0.5 / width**2
 
     @property
     def num_bases(self) -> int:
         return self.means.shape[1]
 
-    def forward(self, D: Float[Tensor, "b"]) -> Float[Tensor, "b n_bases"]:
-        diffs = D.unsqueeze(-1) - self.means
+    def forward(self, dists: Float[Tensor, "b"]) -> Float[Tensor, "b n_bases"]:
+        diffs = dists.unsqueeze(-1) - self.means
 
         return torch.exp(-self.factor *  diffs**2)
 

--- a/notorch/nn/rbf.py
+++ b/notorch/nn/rbf.py
@@ -23,7 +23,7 @@ class RBFEmbedding(nn.Module):
     def forward(self, dists: Float[Tensor, "b"]) -> Float[Tensor, "b n_bases"]:
         diffs = dists.unsqueeze(-1) - self.means
 
-        return torch.exp(-self.factor *  diffs**2)
+        return torch.exp(-self.factor * diffs**2)
 
     def extra_repr(self) -> str:
         return f"d_min={self.means[0]}, d_max={self.means[-1]}, num_bases={len(self.means)}"

--- a/notorch/nn/spatial/pointwise.py
+++ b/notorch/nn/spatial/pointwise.py
@@ -4,7 +4,6 @@ import torch.nn as nn
 
 from notorch.conf import DEFAULT_HIDDEN_DIM
 from notorch.data.models.point_cloud import PointCloud
-from notorch.nn.mlp import MLP
 
 
 class PointwiseEmbed(nn.Module):
@@ -20,21 +19,16 @@ class PointwiseEmbed(nn.Module):
         return P_emb
 
 
-class PointwiseMLP(nn.Module):
-    """Apply an MLP to each point.
+class Pointwise(nn.Module):
+    """Apply a module to the node features."""
 
-    Parameters
-    ----------
-    *args, **kwargs
-        positional and keyword arguments to supply to :func:`notorch.nn.mlp.MLP`
-    """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, module: nn.Module):
         super().__init__()
 
-        self.mlp = MLP(*args, **kwargs)
+        self.module = module
 
     def forward(self, P: PointCloud) -> PointCloud:
         P_emb = copy(P)
-        P_emb.node_feats = self.mlp(P_emb.node_feats)
+        P_emb.node_feats = self.module(P_emb.node_feats)
 
         return P_emb

--- a/notorch/nn/spatial/pointwise.py
+++ b/notorch/nn/spatial/pointwise.py
@@ -29,4 +29,3 @@ class Pointwise(nn.Module):
 
     def forward[T: (PointCloud, BatchedPointCloud)](self, P: T) -> T:
         return P.update(node_feats=self.module(P.node_feats))
-

--- a/notorch/nn/spatial/pointwise.py
+++ b/notorch/nn/spatial/pointwise.py
@@ -3,7 +3,7 @@ from copy import copy
 import torch.nn as nn
 
 from notorch.conf import DEFAULT_HIDDEN_DIM
-from notorch.data.models.point_cloud import PointCloud
+from notorch.data.models.point_cloud import BatchedPointCloud, PointCloud
 
 
 class PointwiseEmbed(nn.Module):
@@ -27,8 +27,6 @@ class Pointwise(nn.Module):
 
         self.module = module
 
-    def forward(self, P: PointCloud) -> PointCloud:
-        P_emb = copy(P)
-        P_emb.node_feats = self.module(P_emb.node_feats)
+    def forward[T: (PointCloud, BatchedPointCloud)](self, P: T) -> T:
+        return P.update(node_feats=self.module(P.node_feats))
 
-        return P_emb

--- a/notorch/nn/spatial/schnet.py
+++ b/notorch/nn/spatial/schnet.py
@@ -36,7 +36,7 @@ class ContinuousFilterConvolution(nn.Module):
         self,
         node_feats: Float[Tensor, "V d_h"],
         coords: Float[Tensor, "V d_r"],
-        batch_index: Int[Tensor, "V"],
+        batch_index: Int[Tensor, "V"] | None,
     ) -> Float[Tensor, "V d_h"]:
         src, dest = radius_graph(coords, self.radius, batch_index).unbind(0)
         D_ij = (coords[src] - coords[dest]).norm(p=2, dim=-1)
@@ -71,7 +71,7 @@ class InteractionLayer(nn.Module):
         self,
         node_feats: Float[Tensor, "V d_h"],
         coords: Float[Tensor, "V d_r"],
-        batch_index: Int[Tensor, "V"],
+        batch_index: Int[Tensor, "V"] | None,
     ) -> Float[Tensor, "V d_h"]:
         node_hiddens = self.W(node_feats)
         node_hiddens = self.cfconv(node_hiddens, coords, batch_index)
@@ -103,6 +103,4 @@ class SchnetBlock(nn.Module):
         for layer in self.layers:
             node_feats = layer(node_feats, P.coords, P.batch_index)
 
-        return BatchedPointCloud(
-            node_feats, P.coords, batch_index=P.batch_index, size=len(P), device_=P.device
-        )
+        return P.update(node_feats=node_feats)

--- a/notorch/utils/utils.py
+++ b/notorch/utils/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import copy
 from enum import StrEnum
 from typing import Iterator, Self
 
@@ -28,3 +29,12 @@ class EnumMapping(StrEnum):
     @classmethod
     def items(cls) -> Iterator[tuple[str, str]]:
         return zip(cls.keys(), cls.values())
+
+
+class UpdateMixin:
+    def update(self, in_place: bool = False, **kwargs) -> Self:
+        other = self if in_place else copy(self)
+        for key, val in kwargs:
+            setattr(other, key, val)
+
+        return other


### PR DESCRIPTION
This pull request includes multiple changes across several files to rename variables for consistency and to integrate the `UpdateMixin` class. The most important changes include renaming `V` and `E` to `node_feats` and `edge_feats` respectively, and updating the relevant methods and classes to reflect these changes. I'm still undecided on the long-term object model of inputs/outputs of message passing blocks. For the purposes of documentation and flexibility, it would be better to have the method signature (2D gnn example):

```python
    def forward(
        self,
        node_feats: Float[Tensor, "V d_v"],
        edge_feats: Float[Tensor, "E d_e"],
        edge_index: Int[Tensor, "2 E"],
        rev_index: Int[Tensor, "E"],
    ) ->: ...
```

but this can be kind of cumbersome in the downstream config. Right now, the object model is `Graph -> Graph` and has corresponding configuration:

```yaml
  chemprop:
    module:
      _target_: notorch.nn.gnn.chemprop.ChempropBlock
      hidden_dim: &latent_dim 256
    in_keys: [graph_embed.G]
    out_keys: [G]
```

the above change would result in something like:

```yaml
  chemprop:
    module:
      _target_: notorch.nn.gnn.chemprop.ChempropBlock
      hidden_dim: &latent_dim 256
    in_keys:
      graph_embed.node_embed: node_feats
      graph_embed.edge_embed: edge_feats
      inputs.edge_index: edge_index
      inputs.rev_index: rev_index
    out_keys: [node_feats, edge_feats, ...]
```

which just seems a lot more cumbersome with little added value. Something to noodle on.