### PR TITLE
Add mixture of experts module

### DIFF
--- a/notorch/nn/moe/moe.py
+++ b/notorch/nn/moe/moe.py
@@ -1,0 +1,23 @@
+import copy
+
+import torch.nn as nn
+
+from notorch.nn.moe.routers import router
+
+
+class MixtureOfExperts[T_mod: nn.Module](nn.Module):
+    def __init__(
+        self,
+        module: T_mod,
+        in_features: int,
+        num_experts: int,
+        reset_parameters: bool = True,
+        **kwargs,
+    ):
+        self.experts = nn.ModuleList([copy.deepcopy(module) for _ in num_experts])
+        self.router = router(in_features, num_experts, **kwargs)
+
+        if reset_parameters:
+            self.experts.apply(
+                lambda m: m.reset_parameters() if hasattr(m, "reset_parameters") else None
+            )

--- a/notorch/nn/moe/moe.py
+++ b/notorch/nn/moe/moe.py
@@ -1,11 +1,29 @@
 import copy
 
+from jaxtyping import Float
+from torch import Tensor
+import torch
 import torch.nn as nn
 
 from notorch.nn.moe.routers import router
 
 
 class MixtureOfExperts[T_mod: nn.Module](nn.Module):
+    r"""
+
+    Parameters
+    ----------
+    module : T_mod
+        any learnable function :math:`f : \mathbb R^p \to \mathbb R_q`
+    in_features : int
+        the number of input features to the function
+    num_experts : int
+        the number of experts :math:`E`
+    reset_parameters : bool, default=True
+        whether to reset the parameters of the input module. Under the hood, this module
+        calls :func:`copy.deepcopy` to generate the mixture. If ``False``, each expert will have
+        identical starting weights.
+    """
     def __init__(
         self,
         module: T_mod,
@@ -21,3 +39,12 @@ class MixtureOfExperts[T_mod: nn.Module](nn.Module):
             self.experts.apply(
                 lambda m: m.reset_parameters() if hasattr(m, "reset_parameters") else None
             )
+
+    def forward(
+        self, inputs: Float[Tensor, "b p"]
+    ) -> tuple[Float[Tensor, "b q"], Float[Tensor, ""]]:
+        outputss = torch.stack([expert(inputs) for expert in self.experts], dim=1)
+        weights, loss = self.router(inputs)
+        output = (outputss * weights.unsqueeze(2)).sum(1)
+
+        return output, loss

--- a/notorch/nn/moe/routers.py
+++ b/notorch/nn/moe/routers.py
@@ -1,0 +1,122 @@
+from abc import abstractmethod
+from jaxtyping import Float
+from torch import Tensor
+import torch
+import torch.distributions as D
+import torch.nn as nn
+
+from notorch.nn.utils import cv, kth_excluding
+
+
+class KeepTopK(nn.Module):
+    def __init__(self, k: int, dim: int = -1, beta: float = 1e6):
+        super().__init__()
+
+        self.k = k
+        self.dim = dim
+        self.beta = beta
+
+    def forward(self, x: Tensor) -> Tensor:
+        values, indices = x.topk(self.k, dim=self.dim, largest=True)
+
+        return torch.full_like(x, self.beta).scatter_(1, indices, values)
+
+    def extra_repr(self) -> str:
+        return f"k={self.k}, dim={self.dim}, beta={self.beta:0.0e}"
+
+
+# def keep_top_k(x: Tensor, k: int, dim: int = -1, beta: float = 1e6) -> Tensor:
+#     values, indices = x.topk(k, dim, largest=True)
+
+#     return torch.full_like(x, beta).scatter_(1, indices, values)
+
+
+class Router(nn.Module):
+    """A :class:`Router` calculates routing weights for a mixture of experts and an auxiliary loss.
+
+    Parameters
+    ----------
+    in_features : int
+        the number of input features to the router
+    num_experts : int
+        the number of experts :math:`E`
+    """
+
+    @abstractmethod
+    def __init__(self, in_features: int, num_experts: int, **kwargs): ...
+
+    @abstractmethod
+    def forward(
+        self, x: Float[Tensor, "b d"]
+    ) -> tuple[Float[Tensor, "b e"], Float[Tensor, ""]]: ...
+
+
+class DenseRouter(Router):
+    def __init__(self, in_features: int, num_experts: int, *, v_imp: float = 0.1):
+        super().__init__()
+
+        self.G = nn.Sequential(nn.Linear(in_features, num_experts, bias=False), nn.Softmax(dim=-1))
+        self.v_imp = v_imp
+
+    def forward(self, x: Float[Tensor, "b d"]) -> tuple[Float[Tensor, "b e"], Float[Tensor, ""]]:
+        g = self.G(x)
+        l_imp = cv(g.sum(dim=0)) ** 2
+
+        return g, self.v_imp * l_imp
+
+
+class SparseRouter(Router):
+    def __init__(
+        self,
+        in_features: int,
+        num_experts: int,
+        *,
+        k: int = 1,
+        noisy: bool = True,
+        v_imp: float = 0.1,
+        v_load: float = 0.1,
+    ):
+        super().__init__()
+
+        if not (1 <= k < num_experts):
+            raise ValueError(f"arg 'k' must be in the range [0, {num_experts - 1}] ! got: {k}.")
+
+        self.W_g = nn.Linear(in_features, num_experts, bias=False)
+        self.W_s = nn.Sequential(nn.Linear(in_features, num_experts, bias=False), nn.Softplus())
+        self.noise = D.Normal(0, 1) if noisy else None
+        self.G = nn.Sequential(KeepTopK(k), nn.Softmax(dim=-1))
+
+        self.k = k
+        self.v_imp = v_imp
+        self.v_load = v_load
+
+    def forward(self, x: Float[Tensor, "b d"]) -> tuple[Float[Tensor, "b e"], Float[Tensor, ""]]:
+        g = self.W_g(x)
+        if self.noise is not None:
+            scale = self.W_s(x)
+            h = g + self.noise.sample((len(x), 1)) * scale
+            P = self.noise.cdf((g - kth_excluding(h, self.k)) / scale)
+            load = P.sum(dim=0)
+            l_load = cv(load) ** 2
+        else:
+            h = g
+            l_load = 0
+
+        l_imp = cv(h.sum(dim=0)) ** 2
+        l_aux = self.v_imp * l_imp + self.v_load * l_load
+
+        return self.G(h), l_aux
+
+
+def router(
+    in_features: int,
+    num_experts: int,
+    k: int | None = None,
+    noisy: bool = True,
+    v_imp: float = 0.1,
+    v_load: float = 0.1,
+) -> Router:
+    if k is None or k == num_experts:
+        return DenseRouter(in_features, num_experts, v_imp=v_imp)
+    else:
+        return SparseRouter(in_features, num_experts, k=k, noisy=noisy, v_imp=v_imp, v_load=v_load)

--- a/notorch/nn/utils.py
+++ b/notorch/nn/utils.py
@@ -1,0 +1,45 @@
+from jaxtyping import Float
+from torch import Tensor
+import torch
+
+
+def cv(x: Tensor, dim: int = 0) -> Tensor:
+    """compute the coefficient of variation of :attr:`x` along dimension :attr:`dim`."""
+    return x.std(dim) / x.mean(dim)
+
+
+
+def kth_excluding(A: Float[Tensor, "*b d"], k: int, *, beta: float = 1e6) -> Float[Tensor, "b d"]:
+    r"""Calculate the :attr:`k`-th largest component of each row ``i`` when excluding column ``j``.
+
+    More specifically, a matrix :math:`A \in \mathbb R^{n \times e}`, calculate each entry
+    :math:`a_{ij}` as the :math:`k`-th largest element in the vector :math:`\mathbf a_i` when
+    excluding the :math:`j`-th element of that vector.
+
+    Parameters
+    ----------
+    A : Tensor
+        a tensor of shape ``b x d``, where ``b`` is the batch dimension and ``d`` is the dimension
+        that the function will be calculated along
+    k : int
+        the :math:`k` to consider when calculating each element
+    beta : float, default=1e6
+        a value to subtract along the diagonal when calculating the output matrix. This value
+        must be larger than the largest range per-row range (
+        :math:`\max_i (\max_j A_{ij} - \min_j A_{ij})`) or this function is not guaranteed to work.
+
+    Raises
+    ------
+    ValueError
+        if :attr:`k` is outside the range :math:`[0, d-1]`
+    """
+    if k >= A.shape[1]:
+        raise ValueError(f"arg 'k' must be in the range [0, {A.shape[-1] - 1}]. got: {k}")
+
+    A = torch.atleast_2d(A)
+    I = torch.eye(A.shape[-1], device=A.device)
+    B = A.unsqueeze(1) - beta * I
+
+    return B.neg().kthvalue(k, dim=-1).values.neg()
+
+coefficient_of_variation = cv


### PR DESCRIPTION
Some preliminary work towards MoE functionality. An unsettled point is on the model for creating the mixture. Currently, we take an already initialized module and just `copy.deepcopy` it $E$ times then reset the weights. This mimics the alternative model of accepting in `experts: list[T: nn.Module]` and inferring the number of experts from there. The latter seems a little more explicit, but functionally similar to the former and unnecessarily more verbose. Open to changing this in the future, though.