### PR TITLE
refactor loss aggregation

### DIFF
--- a/notorch/lightning_models/model.py
+++ b/notorch/lightning_models/model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import lightning as L
+from lightning.pytorch.utilities.types import LRSchedulerConfigType
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule, TensorDictSequential
 import torch.nn as nn
@@ -11,7 +12,9 @@ from torch.optim.lr_scheduler import LRScheduler
 from torch.optim.optimizer import ParamsT
 
 from notorch.conf import TARGET_KEY_PREFIX
-from notorch.types import GroupTransformConfig, LossConfig, LRSchedConfig, ModuleConfig
+from notorch.types import GroupTransformConfig, LossConfig, ModuleConfig
+
+EPS = 1e-6
 
 
 def is_target_key(key: str):
@@ -23,63 +26,85 @@ class NotorchModel(L.LightningModule):
     """A :class:`NotorchModel` is a generic class for composing (mostly) arbitrary models.
 
     The general recipe consists of three configuration dictionaries that define the model, the loss,
-    and the evaluation/testing metrics, respectively. The model configuration dictionary defines a
+    and the evaluation/testing metrics, respectively.
 
     Parameters
     ----------
     modules : dict[str, ModelModuleConfig]
-        A mapping from a name to a dictionary with the keys:
+        A mapping from a name to a dictionary with keys:
 
-        * ``module``: the :class:`~torch.nn.Module` that will be wrapped inside a
+        - ``module``: the :class:`~torch.nn.Module` that will be wrapped inside a
         :class:`~tensordict.nn.TensorDictModule`.
-        * ``in_keys``: the input keys to the module as either:
 
-            - a list of input keys that will be fetched from the intermediate `TensorDict`
-            and passed in as positional arguments to the module
-            - a dictionary mapping from keyword argument name to the keys that will be
+        - ``in_keys``: the keys to retrieve from the tensordict whose values will be passed to the
+        module as either
+
+            - a list of keys that will be passed in as positional arguments
+
+            - a dictionary mapping from keyword argument name to the key that will be
             fetched and supplied to the corresponding argument
 
-        * ``out_keys``: the keys under which the module's output will be placed into the tensordict
+        - ``out_keys``: the keys under which the module's output will be placed into the tensordict
+
         .. note::
             The output values will be placed in a sub-tensordict under the module's name (i.e.,
             the key corresponding to the 3-tuple)
 
     losses : dict[str, LossModuleConfig]
-        A mapping from a name to a dictionary with the keys:
+        A mapping from a loss term name to a dictionary with keys:
 
-        - ``weight``: a float for the term's weight in the total loss
-        - ``module``: a callable that returns a single tensor
-        - ``in_keys``: the input keys of the module
+        - ``module``: any callable that returns a single scalar corresponding to a loss term
+        - ``in_keys``: the values to retrieve from the tensordict whose values will be passed to the
+        module
+
+        Each individual term will be placed into the tensordict under the key ``losses.<NAME>``
+        and will be logged to ``<train|val>/<NAME>``, depending on the whether the model is in
+        training or validation mode.
 
         .. note::
-            Each term will be placed into the tensordict under the key `("loss.<NAME>")`
+            All loss terms will also be calculated in the validation step, so they *not* be
+            defined again in :attr:`metrics`.
 
-        The overall training loss is computed as the weighted sum of all terms. For more
-        details on the ``in_keys`` key, see :attr:`modules`.
+        .. important::
+            The overall training loss will be logged to ``train/loss`` during training, so if you
+            name any individual term simply ``loss``, then it it will be overwritten in the logs.
+            It is best to give each term a descriptive name, such as ``mse`` for an MSE term.
+
+        .. seealso::
+            :paramref:`.modules`
+                Details on the ``in_keys`` key
+
+            :paramref:`train_loss_weights`
+                Details on the how the overall training loss is computed.
 
     metrics : dict[str, LossModuleConfig]
-        A mapping from a name to a dictionary with the keys:
+        A mapping from a metric term name to a dictionary with keys:
 
-        - ``weight``: a float for the term's weight in the total validation loss
-        - ``module``: a callable that returns a single tensor
-        - ``in_keys``: the input keys of the module
+        - ``module``: any callable that returns a single scalar corresponding to a metric term
+        - ``in_keys``: the values to retrieve from the tensordict whose values will be passed to the
+        module
 
-        .. note::
-            Each term will be placed into the tensordict under the key `("metric.<NAME>")`
+        Each invidiual term will be placed into the tensordict under the key `metrics.<NAME>` and
+        will be logged to ``val/<NAME>``
 
-        The overall validation loss is computed as the weighted sum of all loss term values. For
-        details on the ``in_keys`` key, see :attr:`modules`.
+        .. seealso::
+            :paramref:`.modules` for details on the ``in_keys`` key
 
-    transforms : dict[str, GroupTransformConfig] | None
-        A mapping from a name to a dictionary of dictionaries defining the configuration for both
-        prediction and target transforms. The outer dictionary contains two keys, ``"preds"`` and
-        ``"targets"``, each mapping to a dictionary with the following keys:
+            :paramref:`.val_loss_weights`
+            for details on the how the overall validation loss is computed.
 
-        - ``module``: any ``Callable``, typically a :class:`~torch.nn.Module`, that has **no
-        learnable parameters** that will be applied to the corresponding `key` in the input
-        - ``key``: the key in the tensordict whose value will be _modified in place_.
 
-        The ``"preds"`` transforms will be applied to model predictions at inference time via
+    transforms : dict[str, GroupTransformConfig] | None, default=None
+        A mapping from a name to a nested dictionary that defines the configuration for both
+        prediction and target transformation. The nested dictionary contains two keys, ``preds``
+        and ``targets``, each corresponding to an inner dictionary with the following keys:
+
+        - ``module``: any callable that has **no learnable parameters**
+
+        - ``key``: the key in the tensordict whose value will be modified *in place* by the above
+        callable.
+
+        The ``preds`` transforms will be applied to model predictions at inference time via
         :meth:`predict_step` and the ``"targets"`` transforms will be applied to the
         input targets during training and validation.
 
@@ -87,6 +112,34 @@ class NotorchModel(L.LightningModule):
             In the event that the specified keys are not present in the tensordict, then the
             transforms will have no effect. As such, you must take care to ensure the keys have been
             named correctly.
+
+    train_loss_weights : dict[str, float] | None, default=None
+        a mapping from loss term name to its weight in the overall training loss. If ``None``, then
+        each term will be given a weight of ``1.0``.
+
+    val_loss_weights : dict[str, float] | None, default=None
+        a mapping from loss term name to its weight in the overall validation loss. If ``None``,
+        then use the weights of :paramref:`.train_loss_weights`. As mentioned in
+        :paramref:`.losses`, all training loss terms will be calculated in the validation step, so
+        these terms may be included in the overall validation loss.
+
+    optim_factory : Callable[[ParamsT], Optimizer], default=lambda params: Adam(params, lr=1e-4)
+        a callable that takes the model's paramters and returns a :class:`~torch.optim.Optimizer`.
+        By default, will return a :class:`torch.optim.Adam` with a learning rate of `1e-4`.
+
+    lr_sched_factory : Callable[[Optimizer], LRScheduler | LRSchedulerConfigType] | None,
+    default=None
+        an optional callable that accepts in an optimizer and returns a
+        :class:`~torch.optim.lr_scheduler.LRScheduler` or a dictionary configuring the learning rate
+        scheduler.
+
+        .. seealso::
+            :meth:`LightningModule.configure_optimizers` for details on the structure of the
+            dictionary.
+
+    keep_all_output: bool, default=False
+        If ``True``, retain all intermediate tensors in the output tensordict. Otherwise, keep only
+        those required to calculate losses and metrics
     """
 
     def __init__(
@@ -95,8 +148,10 @@ class NotorchModel(L.LightningModule):
         losses: dict[str, LossConfig],
         metrics: dict[str, LossConfig],
         transforms: dict[str, GroupTransformConfig] | None = None,
-        optim_factory: Callable[[ParamsT], Optimizer] = Adam,
-        lr_sched_factory: Callable[[Optimizer], LRScheduler | LRSchedConfig] | None = None,
+        train_loss_weights: dict[str, float] | None = None,
+        val_loss_weights: dict[str, float] | None = None,
+        optim_factory: Callable[[ParamsT], Optimizer] = lambda params: Adam(params, lr=1e-4),
+        lr_sched_factory: Callable[[Optimizer], LRScheduler | LRSchedulerConfigType] | None = None,
         keep_all_output: bool = False,
     ):
         super().__init__()
@@ -111,21 +166,24 @@ class NotorchModel(L.LightningModule):
         ]
 
         selected_out_keys = set()
-        loss_modules = []
+        loss_modules = {}
         for name, loss_config in losses.items():
             module = TensorDictModule(
-                loss_config["module"], loss_config["in_keys"], [f"loss.{name}"], inplace=False
+                loss_config["module"], loss_config["in_keys"], [f"losses.{name}"], inplace=False
             )
-            module._weight = loss_config["weight"]
-            loss_modules.append(module)
+            # module._weight = loss_config["weight"]
+            loss_modules[name] = module
             selected_out_keys.update([k for k in loss_config["in_keys"] if not is_target_key(k)])
-        metric_modules = []
+        metric_modules = {}
         for name, metric_config in metrics.items():
             module = TensorDictModule(
-                metric_config["module"], metric_config["in_keys"], [f"metric.{name}"], inplace=False
+                metric_config["module"],
+                metric_config["in_keys"],
+                [f"metrics.{name}"],
+                inplace=False,
             )
-            module._weight = metric_config["weight"]
-            metric_modules.append(module)
+            # module._weight = metric_config["weight"]
+            metric_modules[name] = module
             selected_out_keys.update([k for k in metric_config["in_keys"] if not is_target_key(k)])
 
         selected_out_keys = None if keep_all_output else list(selected_out_keys)
@@ -146,10 +204,17 @@ class NotorchModel(L.LightningModule):
             for key, modules in transforms_dict.items()
         }
 
+        if train_loss_weights is None:
+            train_loss_weights = {name: 1.0 for name in loss_modules}
+        if val_loss_weights is None:
+            val_loss_weights = train_loss_weights
+
         self.model = TensorDictSequential(*model_modules, selected_out_keys=selected_out_keys)
-        self.losses = nn.ModuleList(loss_modules)
-        self.metrics = nn.ModuleList(metric_modules)
+        self.losses = nn.ModuleDict(loss_modules)
+        self.metrics = nn.ModuleDict(metric_modules)
         self.transforms = nn.ModuleDict(transforms_dict)
+        self.train_loss_weights = train_loss_weights
+        self.val_loss_weights = val_loss_weights
         self.optim_factory = optim_factory
         self.lr_sched_factory = lr_sched_factory
 
@@ -161,37 +226,43 @@ class NotorchModel(L.LightningModule):
         batch = self.transforms["targets"](batch)
 
         loss_dict = {}
-        loss = 0
-        for loss_function in self.losses:
+        train_loss = 0
+        for name, loss_function in self.losses.items():
             out_key = loss_function.out_keys[0]
-            _, name = out_key.split(".")
             value = loss_function(batch)[out_key]
 
             loss_dict[f"train/{name}"] = value
-            loss += loss_function._weight * value
+            train_loss += self.train_loss_weights.get(name, EPS) * value
+            # train_loss += loss_function._weight * value
 
         self.log_dict(loss_dict)
-        self.log("train/loss", loss, prog_bar=True)
+        self.log("train/loss", train_loss, prog_bar=True)
 
-        return loss
+        return train_loss
 
     def validation_step(self, batch: TensorDict, batch_idx: int):
         batch = self(batch)
         batch = self.transforms["targets"](batch)
 
-        val_dict = {}
-        for modules in [self.losses, self.metrics]:
-            metric = 0
-            for module in modules:
-                out_key = module.out_keys[0]
-                _, name = out_key.split(".")
-                value = module(batch)[out_key]
+        loss_dict = {}
+        val_loss = 0
+        for name, module in self.losses.items():
+            out_key = module.out_keys[0]
+            value = module(batch)[out_key]
 
-                val_dict[f"val/{name}"] = value
-                metric += module._weight * value
+            loss_dict[f"val/{name}"] = value
+            val_loss += self.val_loss_weights.get(name, EPS) * value
 
-        self.log_dict(val_dict, batch_size=len(batch))
-        self.log("val/loss", metric, prog_bar=True, batch_size=len(batch))
+        for name, module in self.metrics.items():
+            out_key = module.out_keys[0]
+            # _, name = out_key.split(".")
+            value = module(batch)[out_key]
+
+            loss_dict[f"val/{name}"] = value
+            val_loss += self.val_loss_weights.get(name, EPS) * value
+
+        self.log_dict(loss_dict, batch_size=len(batch))
+        self.log("val/loss", val_loss, prog_bar=True, batch_size=len(batch))
 
     def predict_step(self, batch, batch_idx: int, dataloader_idx: int):
         batch = self(batch)
@@ -207,3 +278,11 @@ class NotorchModel(L.LightningModule):
         lr_scheduler = self.lr_sched_factory(optimizer)
 
         return {"optimizer": optimizer, "lr_scheduler": lr_scheduler}
+
+    def extra_repr(self) -> str:
+        lines = [
+            f"(train_loss_weights): {self.train_loss_weights}",
+            f"(val_loss_weights): {self.val_loss_weights}",
+        ]
+
+        return "\n".join(lines)

--- a/notorch/schedulers.py
+++ b/notorch/schedulers.py
@@ -1,14 +1,14 @@
 from typing import Callable
 
+from lightning.pytorch.utilities.types import LRSchedulerConfigType
+
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LambdaLR, LRScheduler
 
-from notorch.types import LRSchedConfig
-
 
 def meta_lr_sched_factory(
-    scheduler: Callable[[Optimizer], LRScheduler], config: LRSchedConfig
-) -> Callable[[Optimizer], LRSchedConfig]:
+    scheduler: Callable[[Optimizer], LRScheduler], config: LRSchedulerConfigType
+) -> Callable[[Optimizer], LRSchedulerConfigType]:
     def fun(optim: Optimizer):
         return config | {"scheduler": scheduler(optim)}
 

--- a/notorch/transforms/mol.py
+++ b/notorch/transforms/mol.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from jaxtyping import Float
 from numpy.typing import NDArray
-from rdkit.Chem.rdFingerprintGenerator import FingeprintGenerator64, GetMorganGenerator
+from rdkit.Chem.rdFingerprintGenerator import FingerprintGenerator64, GetMorganGenerator
 import torch
 from torch import Tensor
 
@@ -20,7 +20,7 @@ class MolToFP(
     _in_key_: ClassVar[str] = "mol"
     _out_key_: ClassVar[str] = "fp"
 
-    fpgen: FingeprintGenerator64
+    fpgen: FingerprintGenerator64
     bit_fingerprint: InitVar[bool] = True
 
     def __post_init__(self, bit_fingerprint: bool = True):

--- a/notorch/types.py
+++ b/notorch/types.py
@@ -1,10 +1,9 @@
 # ruff: noqa: F401
-from collections.abc import Collection
+from collections.abc import Mapping
 from typing import Callable, Literal, NamedTuple, Protocol, Required, TypedDict
 
-from rdkit.Chem import Atom, Bond, Mol
+from rdkit.Chem import Mol
 from torch import Tensor
-from torch.optim.lr_scheduler import LRScheduler
 
 from notorch.databases.base import Database
 
@@ -33,9 +32,9 @@ class GroupTransformConfig(TypedDict):
     targets: TransformConfig
 
 
-# class TargetConfig(TypedDict, total=False):
-#     columns: Required[Collection[str]]
-#     task: str
+class LossWeightConfig(TypedDict):
+    train: Mapping[str, float] | None
+    val: Mapping[str, float] | None
 
 
 class TargetConfig(TypedDict, total=False):
@@ -53,15 +52,6 @@ class LossConfig(TypedDict):
     module: Callable[..., Tensor]
     in_keys: list[str] | dict[str, str]
     weight: float
-
-
-class LRSchedConfig(TypedDict, total=False):
-    scheduler: Required[LRScheduler]
-    interval: Literal["step", "epoch"]
-    frequency: int
-    monitor: str
-    strict: bool
-    name: str | None
 
 
 Reduction = Literal["mean", "sum", "min", "max"]

--- a/notorch/utils/utils.py
+++ b/notorch/utils/utils.py
@@ -34,7 +34,7 @@ class EnumMapping(StrEnum):
 class UpdateMixin:
     def update(self, in_place: bool = False, **kwargs) -> Self:
         other = self if in_place else copy(self)
-        for key, val in kwargs:
+        for key, val in kwargs.items():
             setattr(other, key, val)
 
         return other


### PR DESCRIPTION
This PR removes the `weight` key from the loss and metric config in favor of two new explicit mappings provided to a `NoTorchModel`: `{train,val}_loss_weights: dict[str, float] | None`. These two mappings specify the weight of each individual term in the overall training and validation loss, respectively. If unspecified (the default), the `train_loss_weights` weights each term as `1.0`, and the `val_loss_weights` are set to the `train_loss_weights`. Note that train loss terms are calculated in the validation step, so these terms are valid entries into the `val_loss_weights` dict. We could think about combining these into a single dictionary with `train` and `val` keys later, but I don't think that does much for us besides eliminating an argument. It arguably makes it less clear IMO.