### PR TITLE
add self-supervised loss

### DIFF
--- a/notorch/nn/loss.py
+++ b/notorch/nn/loss.py
@@ -6,6 +6,35 @@ from torch import Tensor
 import torch.nn as nn
 import torch.nn.functional as F
 
+__all__ = [
+    "SelfSupervisedLoss",
+    "MSE",
+    "BoundedMSE",
+    "MeanVarianceEstimation",
+    "MVE",
+    "Evidential",
+    "BinaryCrossEntropy",
+    "BCE",
+    "CrossEntropy",
+    "XENT",
+    "Dirichlet",
+]
+
+
+class SelfSupervisedLoss(nn.Module):
+    """A pass-through module to backpropagate self-supervised loss terms.
+
+    This class is mostly just syntactic sugar for :class:`torch.nn.Identity` that (1) does input
+    validation to ensure that the input is a scalar and (2) provide an idiomatic name when building
+    config files. There's not much reason to use this at the library level.
+    """
+
+    def forward(self, inputs: Float[Tensor, ""]) -> Float[Tensor, ""]:
+        if inputs.ndim != 0:
+            raise ValueError(f"input must be a scalar! received input with shape: {inputs.shape}")
+
+        return inputs
+
 
 class _LossFunctionBase(nn.Module):
     @abstractmethod

--- a/notorch/nn/moe/moe.py
+++ b/notorch/nn/moe/moe.py
@@ -9,7 +9,7 @@ from notorch.nn.moe.routers import router
 
 
 class MixtureOfExperts[T_mod: nn.Module](nn.Module):
-    r"""
+    r"""Create a mixture of experts of the input module.
 
     Parameters
     ----------
@@ -20,9 +20,11 @@ class MixtureOfExperts[T_mod: nn.Module](nn.Module):
     num_experts : int
         the number of experts :math:`E`
     reset_parameters : bool, default=True
-        whether to reset the parameters of the input module. Under the hood, this module
-        calls :func:`copy.deepcopy` to generate the mixture. If ``False``, each expert will have
-        identical starting weights.
+        If ``True``, reset the parameters of the input module. This module uses
+        :func:`copy.deepcopy` to generate the mixture, so if this is ``False``, each expert will
+        have identical starting weights.
+    **kwargs
+        keyword arguments to supply to :func:`~notorch.nn.moe.routers.router`
     """
     def __init__(
         self,
@@ -44,7 +46,7 @@ class MixtureOfExperts[T_mod: nn.Module](nn.Module):
         self, inputs: Float[Tensor, "b p"]
     ) -> tuple[Float[Tensor, "b q"], Float[Tensor, ""]]:
         outputss = torch.stack([expert(inputs) for expert in self.experts], dim=1)
-        weights, loss = self.router(inputs)
+        weights, aux_loss = self.router(inputs)
         output = (outputss * weights.unsqueeze(2)).sum(1)
 
-        return output, loss
+        return output, aux_loss


### PR DESCRIPTION
this PR just adds a simple pass-through module for self-supervised loss terms. The main use of this class is for the CLI to enable users to add arbitrary intermediate terms computed in the module to the loss calculation. Typically, it would be preferable to add an explicit loss function, but in cases where doing so would require the accumulation of many intermediate values in the tensordict during the forward pass, just calculate it inside the module and return it.

**Ex:** Training a VAE
The interior of a VAE is a regularizer that takes in a hidden vector and outputs $\mu$ and $\log\ \sigma$ of the input sample's latent distribution: $f : \mathbb R^d \rightarrow \mathbb R^{2 \times d}$. It then samples a point $\tilde z \sim p_z$ from this distribution as a noisy approximation of the input $z$  and uses that sample as the conditioning variable for the decoder $p (x | \tilde z)$.

Thus, to calculate both the reconstruction and KL divergence losses for a VAE, we would need to return $z_\mu$, $z_{\log\ \sigma}$, and $\tilde z$ from the variational layer. AFAICT, we never need the first two outside of calculating $\mathrm{KL}$, so they'll just sit on the GPU taking up memory until it's calculated.

Alternatively, we just calculate $\mathrm{KL}$ inside the variational layer, return the corresponding scalar, and pass it through a `SelfSupervisedLoss`. I'm generally in favor of this model because it just keeps things cleaner inside the code, the tensordict, and the config (we would need to name all these variables we don't care about). It also saves us some memory (practically, however, this is negligible: ~1 MB lol).
